### PR TITLE
feat: add channel name for messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -189,6 +189,7 @@ var comfyJS = {
         };
         var extra = {
           id: messageId,
+          channel: channel.replace('#', ''),
           roomId: roomId,
           messageType: messageType,
           messageEmotes: emotes,


### PR DESCRIPTION
This adds the current channel as part of the `extra` argument. This allows for someone to run the chatbot in multiple channels and ensure that command responses are sent to the channel where the command was called.

For example:

```js
ComfyJS.onCommand = (user, command, message, flags, extra) => {
  if (command === 'echo') {
    // without setting the channel, messages in `chrisbiscardi` go to `jlengstorf`
    ComfyJS.Say(message, extra.channel);
  }
}

ComfyJS.Init(
  process.env.TWITCHUSER,
  process.env.OAUTH,
  ['jlengstorf', 'chrisbiscardi']
);
```