### PR TITLE
Adding command cooldown info to the `extra` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ ComfyJS.Init( "MyTwitchChannel" );
     <script type="text/javascript">
       ComfyJS.onCommand = ( user, command, message, flags, extra ) => {
         if( flags.broadcaster && command == "test" ) {
-          if( extra.sinceLastCommand.any < 100 ) {
-            console.log( "The last `!test` was sent less than 100 ms ago" );            
-          }
-
           console.log( "!test was typed in chat" );
         }
       }
@@ -66,6 +62,47 @@ Currently, the flags possible in `onCommand()` are:
 - mod
 - subscriber
 - vip
+
+## Extra Parameter ##
+
+Currently, the `extra` parameter for the `onCommand()` contains the following fields:
+
+- id (the message message)
+- channel
+- roomId
+- messageType
+- messageEmotes
+- isEmoteOnly
+- userId
+- username
+- displayName
+- userColor
+- userBadges
+
+If the message is a command, the `extra` parameter will contain an additional field:
+
+- sinceLastCommand
+
+which contains the information on the time periods in `ms` since the last time any user, or the specific user, has used the same 
+command. This field can be convenient to be used for setting global cooldown or spamming filters. See examples below:
+
+```javascript
+ComfyJS.onChat = ( user, message, flags, self, extra ) => {
+  if( flags.broadcaster && command == "test" ) {
+    if( extra.sinceLastCommand.any < 100 ) {
+      console.log( 
+        `The last '!test' command by any user was sent less than 100 ms ago` 
+      );            
+    }
+
+    if( extra.sinceLastCommand.user < 100 ) {
+      console.log( 
+        `The last '!test' command by this specific user (as denoted by the 'user' parameter) was sent less than 100 ms ago`
+      );            
+    }
+  }
+}
+```
 
 ## Reading Chat Messages ##
 
@@ -96,8 +133,8 @@ OAUTH=[YOUR-OAUTH-PASS HERE] # e.g. OAUTH=oauth:kjh12bn1hsj78445234
 ```javascript
 var ComfyJS = require("comfy.js");
 ComfyJS.onCommand = ( user, command, message, flags, extra ) => {
-  if( command == "test" && extra.sinceLastCommand.user > 100 ) {
-    ComfyJS.Say( "replying to !test with 100 ms user cooldown" );
+  if( command == "test" ) {
+    ComfyJS.Say( "replying to !test" );
   }
 }
 ComfyJS.Init( process.env.TWITCHUSER, process.env.OAUTH );

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ ComfyJS.Init( "MyTwitchChannel" );
     <script type="text/javascript">
       ComfyJS.onCommand = ( user, command, message, flags, extra ) => {
         if( flags.broadcaster && command == "test" ) {
+          if( extra.sinceLastCommand.any < 100 ) {
+            console.log( "The last `!test` was sent less than 100 ms ago" );            
+          }
+
           console.log( "!test was typed in chat" );
         }
       }
@@ -92,8 +96,8 @@ OAUTH=[YOUR-OAUTH-PASS HERE] # e.g. OAUTH=oauth:kjh12bn1hsj78445234
 ```javascript
 var ComfyJS = require("comfy.js");
 ComfyJS.onCommand = ( user, command, message, flags, extra ) => {
-  if( command == "test" ) {
-    ComfyJS.Say( "replying to !test" );
+  if( command == "test" && extra.sinceLastCommand.user > 100 ) {
+    ComfyJS.Say( "replying to !test with 100 ms user cooldown" );
   }
 }
 ComfyJS.Init( process.env.TWITCHUSER, process.env.OAUTH );

--- a/app.js
+++ b/app.js
@@ -260,7 +260,7 @@ var comfyJS = {
           var parts = message.split( / (.*)/ );
           var command = parts[ 0 ].slice( 1 ).toLowerCase();
           var msg = parts[ 1 ] || "";
-          extra[sinceLastCommand] = getTimePeriod( command, userId );
+          extra["sinceLastCommand"] = getTimePeriod( command, userId );
           comfyJS.onCommand( user, command, msg, flags, extra );
         }
         else {


### PR DESCRIPTION
This PR adds a timer to record the last time a user or any user has interacted with a specific command, and report the result in the `extra` parameter, under the new `sinceLastCommand` field.

The `extra.sinceLastCommand` is an object that contains 2 fields: 1) the **`any`** field, which contains the elapsed time in `ms` since the last time any user has used the specific command (as denoted by the `command` parameter), ever; 2) the **`user`** field, which contains the elapsed time in `ms` since the last time this user has used the specific command. 

In addition, I've updated the `README.md` to include the use cases. Please feel free to refactor the examples and make the purposes of the new field more notable. 