### PR TITLE
Fix types for reward event

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,9 +140,50 @@ async function pubsubConnect( channel, password ) {
 					if( messageData.type === "reward-redeemed" ) {
 						let redemption = messageData.data.redemption;
 						// console.log( redemption );
+                        var reward = redemption.reward;
+                        var rewardObj = {
+                          id: reward.id,
+                          channelId: reward.channel_id,
+                          title: reward.title,
+                          prompt: reward.prompt,
+                          cost: reward.cost,
+                          userInputRequired: reward.is_user_input_required,
+                          subOnly: reward.is_sub_only,
+                          image: {
+                            url1x: reward.image.url_1x,
+                            url2x: reward.image.url_2x,
+                            url4x: reward.image.url_4x,
+                          },
+                          defaultImage: {
+                            url1x: reward.default_image.url_1x,
+                            url2x: reward.default_image.url_2x,
+                            url4x: reward.default_image.url_4x,
+                          },
+                          backgroundColor: reward.background_color,
+                          enabled: reward.is_enabled,
+                          paused: reward.is_paused,
+                          inStock: reward.is_in_stock,
+                          maxPerStream: {
+                            enabled: reward.max_per_stream.is_enabled,
+                            maxPerStream: reward.max_per_stream.max_per_stream,
+                          },
+                          shouldRedemptionsSkipRequestQueue: reward.should_redemptions_skip_request_queue,
+                          templateId: reward.template_id,
+                          updatedForIndicatorAt: reward.updated_for_indicator_at,
+                          maxPerUserPerStream: {
+                            enabled: reward.max_per_user_per_stream.is_enabled,
+                            maxPerUserPerStream: reward.max_per_user_per_stream.max_per_user_per_stream,
+                          },
+                          globalCooldown: {
+                            enabled: reward.global_cooldown.is_enabled,
+                            globalCooldownSeconds: reward.global_cooldown.global_cooldown_seconds,
+                          },
+                          redemptionsRedeemedCurrentStream: reward.redemptions_redeemed_current_stream,
+                          cooldownExpiresAt: reward.cooldown_expires_at,
+                        };
 						var extra = {
 				          channelId: redemption.channel_id,
-				          reward: redemption.reward,
+				          reward: rewardObj,
 				          rewardFulfilled: redemption.status === "FULFILLED",
 				          userId: redemption.user.id,
 				          username: redemption.user.login,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/instafluff/ComfyJS
 // Definitions by: Michael Jolley <https://github.com/michaeljolley>
 
-// Last updated: 2020/08/01
+// Last updated: 2021/01/30
 
 import { Badges, Client, RoomState, SubMethods } from "tmi.js";
 
@@ -35,13 +35,58 @@ export type OnMessageFlags = {
 
 export type OnRewardExtra = {
   channelId: string;
-  reward: string;
+  reward: Reward;
   rewardFulfilled: boolean;
   userId: string;
   username: string;
   displayName: string;
   customRewardId: string;
   timestamp: string;
+}
+
+export type Reward = {
+  id: string;
+  channelId: string;
+  title: string;
+  prompt: string;
+  cost: number;
+  userInputRequired: boolean;
+  subOnly: boolean;
+  image: Image;
+  defaultImage: Image;
+  backgroundColor: string;
+  enabled: boolean;
+  paused: boolean;
+  inStock: boolean;
+  maxPerStream: RewardMaxPerStream;
+  shouldRedemptionsSkipRequestQueue: boolean;
+  templateId: string;
+  updatedForIndicatorAt: string;
+  maxPerUserPerStream: RewardMaxUserPerStream;
+  globalCooldown: RewardGlobalCooldown;
+  redemptionsRedeemedCurrentStream: string;
+  cooldownExpiresAt: string;
+}
+
+export type RewardMaxPerStream = {
+  enabled: boolean;
+  maxPerStream: number;
+}
+
+export type RewardMaxUserPerStream = {
+  enabled: boolean;
+  maxPerUserPerStream: number;
+}
+
+export type RewardGlobalCooldown = {
+  enabled: boolean;
+  globalCooldownSeconds: number;
+}
+
+export type Image = {
+  url1x: string;
+  url2x: string;
+  url4x: string;
 }
 
 export type OnMessageExtra = {


### PR DESCRIPTION
The type has been inspired on this dump I got from the extra parameter in `onReward`.

A thing to note here is that the custom reward id changes with every redemption but that `reward.id` stays the same
```javascript
{
  channelId: '91097747',
  reward: {
    id: '80a644d9-4486-40a7-8e83-703e9c3931ae',
    channel_id: '91097747',
    title: 'Change LED Color',
    prompt: 'Change my background LED color. Possible colors are red, orange, dark, yellow, light, green, pea, cyan, light, sky_blue, blue, dark, magenta, purple, pink. Enter something else for a random color.',
    cost: 1000,
    is_user_input_required: true,
    is_sub_only: false,
    image: {
      url_1x: 'https://static-cdn.jtvnw.net/custom-reward-images/91097747/80a644d9-4486-40a7-8e83-703e9c3931ae/2e3f2ae8-01af-4704-8d29-8b57c409ca38/custom-1.png',
      url_2x: 'https://static-cdn.jtvnw.net/custom-reward-images/91097747/80a644d9-4486-40a7-8e83-703e9c3931ae/2e3f2ae8-01af-4704-8d29-8b57c409ca38/custom-2.png',
      url_4x: 'https://static-cdn.jtvnw.net/custom-reward-images/91097747/80a644d9-4486-40a7-8e83-703e9c3931ae/2e3f2ae8-01af-4704-8d29-8b57c409ca38/custom-4.png'
    },
    default_image: {
      url_1x: 'https://static-cdn.jtvnw.net/custom-reward-images/default-1.png',
      url_2x: 'https://static-cdn.jtvnw.net/custom-reward-images/default-2.png',
      url_4x: 'https://static-cdn.jtvnw.net/custom-reward-images/default-4.png'
    },
    background_color: '#258200',
    is_enabled: true,
    is_paused: false,
    is_in_stock: false,
    max_per_stream: { is_enabled: false, max_per_stream: 0 },
    should_redemptions_skip_request_queue: true,
    template_id: null,
    updated_for_indicator_at: '2021-01-30T08:51:27.364157802Z',
    max_per_user_per_stream: { is_enabled: false, max_per_user_per_stream: 0 },
    global_cooldown: { is_enabled: true, global_cooldown_seconds: 600 },
    redemptions_redeemed_current_stream: null,
    cooldown_expires_at: '2021-01-30T09:03:26Z'
  },
  rewardFulfilled: true,
  userId: '91097747',
  username: 'duncte123',
  displayName: 'duncte123',
  customRewardId: 'ffdea543-747c-4234-9dcc-e41364348408',
  timestamp: '2021-01-30T08:53:26.708650405Z'
}
```