### PR TITLE
Strip "oauth:" prefix from ChannelReward functions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1345,6 +1345,7 @@ var comfyJS = {
   },
   GetChannelRewards: async function( clientId, manageableOnly = false ) {
       if( channelPassword ) {
+          channelPassword = channelPassword.replace( "oauth:", "" );
           if( !channelInfo ) {
               let info = await fetch( `https://api.twitch.tv/helix/users?login=${mainChannel}`, {
                   headers: {
@@ -1368,6 +1369,7 @@ var comfyJS = {
   },
   CreateChannelReward: async function( clientId, rewardInfo ) {
       if( channelPassword ) {
+          channelPassword = channelPassword.replace( "oauth:", "" );
           if( !channelInfo ) {
               let info = await fetch( `https://api.twitch.tv/helix/users?login=${mainChannel}`, {
                   headers: {
@@ -1394,6 +1396,7 @@ var comfyJS = {
   },
   UpdateChannelReward: async function( clientId, rewardId, rewardInfo ) {
       if( channelPassword ) {
+          channelPassword = channelPassword.replace( "oauth:", "" );
           if( !channelInfo ) {
               let info = await fetch( `https://api.twitch.tv/helix/users?login=${mainChannel}`, {
                   headers: {
@@ -1420,6 +1423,7 @@ var comfyJS = {
   },
   DeleteChannelReward: async function( clientId, rewardId ) {
       if( channelPassword ) {
+          channelPassword = channelPassword.replace( "oauth:", "" );
           if( !channelInfo ) {
               let info = await fetch( `https://api.twitch.tv/helix/users?login=${mainChannel}`, {
                   headers: {

--- a/examples/twitchdemo.html
+++ b/examples/twitchdemo.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/comfy.js@1.1.6/dist/comfy.min.js"></script>
+    <script src="../dist/comfy.js"></script>
   </head>
   <body>
     <h1 id="math"></h1>


### PR DESCRIPTION
- Mirrors existing behaviour from `pubsubConnect` to strip `oauth:` from channel password.
- Updates twitchdemo.html with local comfy.js
- Fixes #69.