### PR TITLE
Added firstMessage to OnMessageFlags

### DIFF
--- a/app.js
+++ b/app.js
@@ -1053,6 +1053,7 @@ var comfyJS = {
         var isEmoteOnly = userstate[ "emote-only" ] || false;
         var messageType = userstate[ "message-type" ];
         var customRewardId = userstate[ "custom-reward-id" ] || null;
+        var isFirstMessage = ( userstate[ "first-msg" ] && userstate[ "first-msg" ] === "1" ) || false;
         var flags = {
           broadcaster: isBroadcaster,
           mod: isMod,
@@ -1060,7 +1061,8 @@ var comfyJS = {
           subscriber: isSubscriber || isFounder,
           vip: isVIP,
           highlighted: isHighlightedMessage,
-          customReward: !!customRewardId
+          customReward: !!customRewardId,
+          firstMessage: isFirstMessage
         };
         var extra = {
           id: messageId,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,6 +31,7 @@ export type OnMessageFlags = {
   vip: boolean;
   highlighted: boolean;
   customReward: boolean;
+  firstMessage: boolean;
 }
 
 export type OnRewardExtra = {


### PR DESCRIPTION
Twitch now passes `first-msg` in tags which is passed to us via TMI.js

This PR adds a new `firstMessage` boolean to `OnMessageFlags` to pass that data along. 

This boolean is true when a user submits their first chat message to the channel.

Also, updates the TypeScript definitions for this new property.

Cheers!